### PR TITLE
Add resumé to website

### DIFF
--- a/cypress/integration/resume.js
+++ b/cypress/integration/resume.js
@@ -1,0 +1,28 @@
+describe(`The Resume page`, () => {
+
+  beforeEach(() => {
+  });
+
+  it(`should be accessible from url /resume`, () => {
+    cy.visit('/resume')
+    cy.get('h1').should('contain', 'Resume')
+  })
+
+  it(`should be accessible from a Home page link`, () => {
+    cy.visit('/')
+    cy.get('a[href*=resume]').click()
+    cy.location('pathname').should('contain', '/resume')
+    cy.get('h1').should('contain', 'Resume')
+  })
+
+  it(`should have social links`, () => {
+    cy.visit('/resume')
+    cy.get('a[href*=github]').should('exist')
+    cy.get('a[href*=gitlab]').should('exist')
+    cy.get('a[href*=stackoverflow]').should('exist')
+    cy.get('a[href*=linked]').should('exist')
+    cy.get('a[href*=codepen]').should('exist')
+    cy.get('a[href*=lacourt.dev]').should('exist')
+  })
+
+});


### PR DESCRIPTION
- migrate https://github.com/doppelganger9/react-cv-template into this blog.
- it's not just a blog anymore, but my personal website.
- add a link from the home page.