### PR TITLE
i18n via Routing

### DIFF
--- a/src/lib/components/Lang.svelte
+++ b/src/lib/components/Lang.svelte
@@ -3,7 +3,16 @@
   import { onMount } from 'svelte';
 
   onMount(() => {
-    switchLang(navigator.language.split('-')[0]);
+    if (window.location.pathname.startsWith('/en') || window.location.pathname.startsWith('/fr')) {
+      // let's assume we already handled the default lang.
+      const langInWindowLocation = window.location.pathname.substring(1,3);
+      console.debug(`mounting Lang component, keeping lang store to the previous value (set in the current window.location) : ${langInWindowLocation}`);
+      switchLang(langInWindowLocation);
+    } else {
+      // nothing was setup so we will use the navigator language as a starting point.
+      console.debug(`mounting Lang component, defaulting lang store to navigator.language.split('-')[0]=${navigator.language.split('-')[0]}`);
+      switchLang(navigator.language.split('-')[0]);
+    }
   })
 
 </script>

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { i18n } from '$lib/stores/i18n.js';
+  import { i18n, lang } from '$lib/stores/i18n.js';
 
   export let level = 'h1';
 </script>
@@ -27,8 +27,8 @@
 </style>
 <div class='title-bar' data-cy='title-bar'>
 {#if level == 'h1'}
-  <h1><a href='/'>{$i18n`title`}</a></h1>
+  <h1><a href={'/' + $lang}>{$i18n`title`}</a></h1>
 {:else}
-  <h3><a href='/'>{$i18n`title`}</a></h3>
+  <h3><a href={'/' + $lang}>{$i18n`title`}</a></h3>
 {/if}
 </div>

--- a/src/lib/posts.js
+++ b/src/lib/posts.js
@@ -95,8 +95,17 @@ function cleanAndDedupe(arrayWithDuplicateOrFalsyElements) {
   return Array.from(new Set(arrayWithoutFalsies));
 }
 
-export function getPostForSlug(slug) {
-  return POSTS.find(p => p.slug === slug);
+export function getPostForSlug(slug, lang) {
+  let found = null;
+  if (lang) {
+    found = POSTS.find(p => (p.slug === slug) && (p.metadata.lang === lang));
+  } else {
+    // no lang, slug only
+    found = POSTS.find(p => p.slug === slug);
+  }
+  if (found) console.log(`found post for slug ${slug} lang ${lang}`)
+    else console.log(`NOT FOUND post for slug ${slug} lang ${lang}`);
+  return found;
 }
 
 export function getPostForDateSlug(slug) {
@@ -104,11 +113,18 @@ export function getPostForDateSlug(slug) {
   return regexp_YYYY_MM_DD.test(slug) ? getPostForSlug(slug) : undefined;
 }
 
-export function loadPostForSlug(slug) {
-  const post = getPostForSlug(slug);
+export function loadPostForSlug(slug, lang) {
+  const post = getPostForSlug(slug, lang);
   if (!post) {
     error(404, 'Oh no! The requested page could not be found.');
   }
 
   return post;
+}
+
+export function filterForLang(postList, lang) {
+  const founds = postList.filter(post => post.metadata.lang === lang);
+  console.debug(lang);
+  console.log(`found ${founds.length} posts for lang ${lang} : ${founds.map(p => p.slug).reduce((prev, curr) => prev + '\n - ' + curr, '')}`);
+  return founds;
 }

--- a/src/lib/stores/i18n.js
+++ b/src/lib/stores/i18n.js
@@ -1,3 +1,4 @@
+import { goto } from '$app/navigation';
 import { writable } from 'svelte/store';
 
 /**
@@ -110,9 +111,34 @@ export function switchLang(newLang) {
   if (langs.indexOf(newLang) < 0) {
     return;
   }
-  lang.set(newLang);
-  console.log(`i18n switching to "${newLang}"`);
-  i18n.set(i18nTemplateLiteralCurried(newLang));
+  const oldLang = ''+currentLang;
+  const urlContainsCurrentLang = window.location.pathname.indexOf(oldLang)>=0;
+  if (oldLang !== newLang) {
+    lang.set(newLang);
+    console.log(`i18n switching to "${newLang}"`);
+    i18n.set(i18nTemplateLiteralCurried(newLang));
+    if (window.location.pathname.indexOf(oldLang)>=0) {
+        // already contains a lang in url, change it
+        const targetUrl = '/' + newLang + window.location.pathname.substring(3);
+        console.debug(oldLang, newLang, window.location.pathname, targetUrl);
+        goto(targetUrl); // TODO add other stuff ?
+      }
+    if (window.location.pathname.indexOf(newLang)<0 
+      && window.location.pathname.indexOf(oldLang)<0) {
+        // already contains a lang in url, add it
+        const targetUrl = '/' + newLang + window.location.pathname;
+        console.debug(oldLang, newLang, window.location.pathname, targetUrl);
+        goto(targetUrl); // TODO add other stuff ?
+      }
+  } else {
+    if (!urlContainsCurrentLang) {
+      const targetUrl = '/' + newLang + window.location.pathname;
+      console.debug(oldLang, window.location.pathname, targetUrl);
+      goto(targetUrl); // TODO add other stuff ?      
+    }
+
+    console.debug("same lang, will do nothing");
+  }
 }
 
 const DEFAULT_LANG = 'en';

--- a/src/posts/2019-03-01-hello-world-FR.md
+++ b/src/posts/2019-03-01-hello-world-FR.md
@@ -1,0 +1,54 @@
+---
+title: Hello 👋 World 🌎
+date: 2019-03-01T22:12:03
+description: Premier billet sur ce blog ! Mon intention et l'objectif de ce blog
+published: true
+lang: fr
+tags: first, starting
+keywords: hello world, first post, starting new blog
+slug: hello-world
+---
+
+## Salut ! 👋
+
+Ceci est mon premier article sur mon nouveau blog ! Quelle excitation !
+
+Je suis sûr que j'écrirai beaucoup plus de choses intéressantes à l'avenir.
+
+## Objectif 🤔
+
+### Open Source
+
+Mon intention pour ce blog est qu'il soit entièrement **Open Source**.
+
+Vous pouvez consulter tous les commits [sur le dépôt Github](https://github.com/doppelganger9/blog).
+
+### Pile technique
+
+Au début, je l'ai construit avec [GatsbyJS](https://www.gatsbyjs.org/) et ⚛️**React**.
+
+#### et migrations
+
+Depuis lors, il a été migré vers [Sapper](https://sapper.svelte.dev), propulsé par [Svelte](https://svelte.dev). Et actuellement sur [SvelteKit](https://svelte.dev/docs/kit/introduction) !
+
+## Construction
+
+Je posterai ici au début pour expliquer et illustrer des aspects techniques pendant la construction de ce blog, au lieu d'utiliser des exemples d'utilisation vagues.
+
+J'aime être pragmatique et pratique et je veux le montrer !
+
+De plus, je veux vous montrer les méandres de la recherche d'une solution fonctionnelle; je veux que vous fassiez le voyage avec moi, au lieu de simplement voir un résultat final et parfait.
+
+## Fréquence
+
+J'avais l'intention de poster au moins de temps en temps. Oh, wow, ça, c'est de l'ambition ! 🤪
+
+## Contact
+
+A un moment j'ai [ajouté la possibilité de commenter les articles](/2021/11/28), et si vous voulez vraiment contribuer ou interagir avec moi ou ce blog, choisissez ce qui vous convient :
+
+- envoyez-moi un mail à [david@lacourt.dev](mailto://david@lacourt.dev)
+- une discussion ci-dessous sur [le dépôt de ce blog sur GitHub](https://github.com/doppelganger9/blog), ouvrez un problème ou commentez une Pull Request...
+- (je ne consulte plus Twitter/X)
+- dernièrement je suis un peu sur [BlueSky](https://bsky.app/profile/doppelganger9.bsky.social)
+- ... sinon il reste toujours mon profil sur [LinkedIn](https://fr.linkedin.com/in/davidlacourt)

--- a/src/routes/en/+page.js
+++ b/src/routes/en/+page.js
@@ -1,0 +1,41 @@
+import { filterForLang, getPublishedPosts, getAllCategoriesOfPublishedPosts, getAllTagsOfPublishedPosts } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * Transform a post extracted from markdown to a usable view model.
+ */
+function mapStoredPostToViewablePost(storedPost) {
+  return {
+    title: storedPost.metadata.title,
+    date: storedPost.metadata.dateString,
+    description: storedPost.metadata.description,
+    slug: 'en/' + storedPost.slug,
+    lang: storedPost.metadata.lang,
+    minutesToRead: storedPost.minutesToRead,
+    categories: storedPost.metadata.category,
+    tags: storedPost.metadata.tags,
+  };
+}
+
+/**
+ * Loads all posts for the lang specified in the slug
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export async function load() {
+  // this appears during build and in the browser while `npx http-server build`
+  //const publishedPosts = getPublishedPosts();
+  const currentLang = 'en';
+  const publishedPosts = filterForLang(getPublishedPosts(), currentLang);
+  const allTags = getAllTagsOfPublishedPosts(publishedPosts);
+  const allCategories = getAllCategoriesOfPublishedPosts(publishedPosts);
+
+  const contents = publishedPosts.map(mapStoredPostToViewablePost);
+  console.log(`lang=en / pages : ${contents.length} / tags: ${allTags.length} / categorie: ${allCategories.length}`);
+
+  return {
+    posts: contents,
+    tags: allTags,
+    categories: allCategories,
+  };
+}

--- a/src/routes/en/+page.svelte
+++ b/src/routes/en/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import TitleBar from '$lib/components/TitleBar.svelte';
   import ArticleFooter from '$lib/components/ArticleFooter.svelte';
-  import { i18n, lang } from '$lib/stores/i18n.js';
+  import { i18n } from '$lib/stores/i18n.js';
   import { siteUrl } from '$lib/stores/config.js';
   import { selectedCategory } from '$lib/stores/category'
   import Categories from '$lib/components/Categories.svelte'
@@ -9,6 +9,9 @@
 
   /** @type {import('./$types').PageData} */
   export let data;
+  
+  console.log(`view | lang=en / pages : ${data.posts.length} / tags: ${data.tags.length} / categories: ${data.categories.length}`);
+
 </script>
 
 <svelte:head>
@@ -39,8 +42,7 @@
 <Categories mode="horizontal" data={data.categories}/>
 
 <ul data-cy="blog-posts-list">
-  {#each data.posts.filter(p => (!$selectedCategory || !p.categories || p.categories?.indexOf($selectedCategory)>=0) 
-    && (!$lang || !p.lang || p.lang === $lang)) as post}
+  {#each data.posts.filter(p => !$selectedCategory || !p.categories || p.categories?.indexOf($selectedCategory)>=0) as post}
     <!-- we're using the non-standard `rel=prefetch` attribute to
         tell SvelteKit to load the data for the page as soon as
         the user hovers over the link or taps it, instead of

--- a/src/routes/en/[slug]/+page.js
+++ b/src/routes/en/[slug]/+page.js
@@ -1,0 +1,10 @@
+import { loadPostForSlug } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export function load({ params }) {
+  return loadPostForSlug(params.slug, 'en');
+}

--- a/src/routes/en/[slug]/+page.svelte
+++ b/src/routes/en/[slug]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+  import Post from '$lib/components/Post.svelte';
+
+  /** @type {import('./$types').PageData} */
+  export let data;
+</script>
+
+<Post post={data}/>

--- a/src/routes/en/[year]/[month]/[day]/+page.js
+++ b/src/routes/en/[year]/[month]/[day]/+page.js
@@ -1,0 +1,12 @@
+import { loadPostForSlug } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export function load({ params }) {
+  console.log(`lang=en / page slug: ${params.year}/${params.month}/${params.day}`);
+
+  return loadPostForSlug(`${params.year}/${params.month}/${params.day}`, 'en');
+}

--- a/src/routes/en/[year]/[month]/[day]/+page.svelte
+++ b/src/routes/en/[year]/[month]/[day]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+  import Post from '$lib/components/Post.svelte';
+
+  /** @type {import('./$types').PageData} */
+  export let data;
+</script>
+
+<Post post={data} />

--- a/src/routes/fr/+page.js
+++ b/src/routes/fr/+page.js
@@ -1,0 +1,41 @@
+import { filterForLang, getPublishedPosts, getAllCategoriesOfPublishedPosts, getAllTagsOfPublishedPosts } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * Transform a post extracted from markdown to a usable view model.
+ */
+function mapStoredPostToViewablePost(storedPost) {
+  return {
+    title: storedPost.metadata.title,
+    date: storedPost.metadata.dateString,
+    description: storedPost.metadata.description,
+    slug: 'fr/' + storedPost.slug,
+    lang: storedPost.metadata.lang,
+    minutesToRead: storedPost.minutesToRead,
+    categories: storedPost.metadata.category,
+    tags: storedPost.metadata.tags,
+  };
+}
+
+/**
+ * Loads all posts for the lang specified in the slug
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export async function load() {
+  // this appears during build and in the browser while `npx http-server build`
+  //const publishedPosts = getPublishedPosts();
+  const currentLang = 'fr';
+  const publishedPosts = filterForLang(getPublishedPosts(), currentLang);
+  const allTags = getAllTagsOfPublishedPosts(publishedPosts);
+  const allCategories = getAllCategoriesOfPublishedPosts(publishedPosts);
+
+  const contents = publishedPosts.map(mapStoredPostToViewablePost);
+  console.log(`lang=fr / pages : ${contents.length} / tags: ${allTags.length} / categorie: ${allCategories.length}`);
+
+  return {
+    posts: contents,
+    tags: allTags,
+    categories: allCategories,
+  };
+}

--- a/src/routes/fr/+page.svelte
+++ b/src/routes/fr/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import TitleBar from '$lib/components/TitleBar.svelte';
   import ArticleFooter from '$lib/components/ArticleFooter.svelte';
-  import { i18n, lang } from '$lib/stores/i18n.js';
+  import { i18n } from '$lib/stores/i18n.js';
   import { siteUrl } from '$lib/stores/config.js';
   import { selectedCategory } from '$lib/stores/category'
   import Categories from '$lib/components/Categories.svelte'
@@ -9,6 +9,9 @@
 
   /** @type {import('./$types').PageData} */
   export let data;
+
+  console.log(`view | lang=fr / pages : ${data.posts.length} / tags: ${data.tags.length} / categories: ${data.categories.length}`);
+
 </script>
 
 <svelte:head>
@@ -39,8 +42,7 @@
 <Categories mode="horizontal" data={data.categories}/>
 
 <ul data-cy="blog-posts-list">
-  {#each data.posts.filter(p => (!$selectedCategory || !p.categories || p.categories?.indexOf($selectedCategory)>=0) 
-    && (!$lang || !p.lang || p.lang === $lang)) as post}
+  {#each data.posts.filter(p => !$selectedCategory || !p.categories || p.categories?.indexOf($selectedCategory)>=0) as post}
     <!-- we're using the non-standard `rel=prefetch` attribute to
         tell SvelteKit to load the data for the page as soon as
         the user hovers over the link or taps it, instead of

--- a/src/routes/fr/[slug]/+page.js
+++ b/src/routes/fr/[slug]/+page.js
@@ -1,0 +1,10 @@
+import { loadPostForSlug } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export function load({ params }) {
+  return loadPostForSlug(params.slug, 'fr');
+}

--- a/src/routes/fr/[slug]/+page.svelte
+++ b/src/routes/fr/[slug]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+  import Post from '$lib/components/Post.svelte';
+
+  /** @type {import('./$types').PageData} */
+  export let data;
+</script>
+
+<Post post={data}/>

--- a/src/routes/fr/[year]/[month]/[day]/+page.js
+++ b/src/routes/fr/[year]/[month]/[day]/+page.js
@@ -1,0 +1,12 @@
+import { loadPostForSlug } from '$lib/posts';
+
+export const prerender = true;
+
+/**
+ * @type {import('@sveltejs/kit').PageLoad}
+ */
+export function load({ params }) {
+  console.log(`lang=fr / page slug: ${params.year}/${params.month}/${params.day}`);
+
+  return loadPostForSlug(`${params.year}/${params.month}/${params.day}`, 'fr');
+}

--- a/src/routes/fr/[year]/[month]/[day]/+page.svelte
+++ b/src/routes/fr/[year]/[month]/[day]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+  import Post from '$lib/components/Post.svelte';
+
+  /** @type {import('./$types').PageData} */
+  export let data;
+</script>
+
+<Post post={data} />


### PR DESCRIPTION
This commits adds fr/ and en/ routes; also uses browser language to initialize the language in store and then changes the URL; next the URL is checked to see if the language is there or else using browser language. A lot of boilerplate duplicate code to handle this, I'm not quite satisfied by this solution so I will create another branch with another solution. Because all the pages are redirected and need to be duplicated in the fr and en routes ; but I want to keep the old non-i18n routes for SEO and old links.

Tests are not fixed.