### PR TITLE
fixing language selection persistance

### DIFF
--- a/src/lib/components/Lang.svelte
+++ b/src/lib/components/Lang.svelte
@@ -1,9 +1,16 @@
 <script>
+  import { get } from 'svelte/store';
   import { switchLang, lang } from '$lib/stores/i18n.js';
   import { onMount } from 'svelte';
 
   onMount(() => {
-    switchLang(navigator.language.split('-')[0]);
+    const currentLang = get(lang);
+    if (!currentLang) {
+      const browserLang = navigator.language.split('-')[0];
+      switchLang(browserLang);
+    } else {
+      switchLang(currentLang);
+    }
   })
 
 </script>

--- a/src/lib/stores/i18n.js
+++ b/src/lib/stores/i18n.js
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-
+import { storable } from '$lib/stores/storable';
 /**
  * Dumb i18n
  *
@@ -22,7 +22,7 @@ import { writable } from 'svelte/store';
  **/
 
 const langs = ['en', 'fr'];
-let currentLang = '';
+let currentLang = undefined;
 
 let labelsByLang = {
   "en": {
@@ -115,8 +115,6 @@ export function switchLang(newLang) {
   i18n.set(i18nTemplateLiteralCurried(newLang));
 }
 
-const DEFAULT_LANG = 'en';
-
 const i18nTemplateLiteralCurried = (lang) => (literals, ...expressions) => {
   let safeXP = [...expressions, ''];
   const originalString = literals.map((literal, i) => literal + safeXP[i]).join('');
@@ -127,9 +125,10 @@ const i18nTemplateLiteralCurried = (lang) => (literals, ...expressions) => {
   return res ? res : originalString;
 }
 
-console.log(`i18n defaulting to "${DEFAULT_LANG}"`);
-export const lang = writable(DEFAULT_LANG);
+export const lang = storable('lang', null);
+
 lang.subscribe(newLang => {
   currentLang = ''+newLang;
 });
+const DEFAULT_LANG = 'en';
 export const i18n = writable(i18nTemplateLiteralCurried(DEFAULT_LANG));

--- a/src/lib/stores/storable.ts
+++ b/src/lib/stores/storable.ts
@@ -1,0 +1,34 @@
+import { get, writable } from 'svelte/store';
+
+export function storable(key, data) {
+  console.debug(`creating new storable with key ${key}`);
+  const internalKey = `sv-storable_${key}`;
+  const store = writable(data);
+  const { subscribe, set, update } = store;
+  const isBrowser = typeof window !== 'undefined';
+
+  if (isBrowser && localStorage[internalKey]) {
+    console.debug(`reading value from localStorage: ${localStorage[internalKey]}`);
+    set(JSON.parse(localStorage[internalKey]));
+  }
+
+  return {
+    subscribe,
+    set: n => {
+      console.debug(`called set on storable with new value : ${n}`);
+      // when setting a store's value, first, persist it in localStorage.
+      isBrowser && (localStorage[internalKey] = JSON.stringify(n));
+      // then set as usual
+      set(n);
+    },
+    update: cb => {
+      const currentValue = get(store);
+      const updatedStoreValue = cb(currentValue);
+      console.debug(`called update on storable with current value : ${currentValue} and updatedValue: ${updatedStoreValue}`);
+      // when updating a store's value, first, persist it in localstorage
+      isBrowser && (localStorage[internalKey] = JSON.stringify(updatedStoreValue));
+      // then set as usual
+      set(updatedStoreValue);
+    }
+  };
+}


### PR DESCRIPTION
Bug: when changing language, and reloading or navigating, the language selected can be lost if the app is reloaded (because Stores are re-constructed with initial values).

Fix:
- using localStorage to persist chosen value, by default navigator.language
- using null value in the store as initial value for the Lang component to be able to provide the navigator language when initially switching language.