### PR TITLE
save Markdown content in localstorage, using Svelte 5 runes

### DIFF
--- a/src/routes/playground/md/+page.svelte
+++ b/src/routes/playground/md/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { marked } from 'marked';
+  import TabCounter from '../tab-counter/+page.svelte';
+  import SampleCustomElement from '/src/lib/components/SampleCustomElement.svelte';
 
 	// Clé pour le localStorage
 	const CONTENT_STORAGE_KEY = 'svelte-markdown-editor-content';
@@ -83,6 +85,25 @@ code
    alors
 \`\`\`
 ---
+
+## Custom Web Element:
+
+Voir [la doc de Svelte](https://svelte.dev/docs/svelte/custom-elements).
+
+### un compteur :
+
+\`<sample-custom-element></sample-custom-element>\`
+
+<sample-custom-element></sample-custom-element>
+
+## Wow, j'importe une autre page :
+
+Et il y a même des attributs qui pilotent son comportement !
+
+\`<tab-counter showHelp="false" updateTitleWithTimeElapsed="false" />\`
+
+<tab-counter showHelp="false" updateTitleWithTimeElapsed="false" />
+
 `;
 
 

--- a/src/routes/playground/md/+page.svelte
+++ b/src/routes/playground/md/+page.svelte
@@ -1,13 +1,35 @@
-<script>
-	// Import markdown conversion library
-  import { marked } from 'marked'
-  
-	// Declare a variable to store the markdown data
-  let markdown = `Titre
+<script lang="ts">
+	import { marked } from 'marked';
+
+	// Clé pour le localStorage
+	const CONTENT_STORAGE_KEY = 'svelte-markdown-editor-content';
+  const EDITOR_VISIBILITY_KEY = 'svelte-markdown-editor-visibility';
+	
+  // Visibilité par défaut de l'éditeur
+	const DEFAULT_EDITOR_VISIBLE = true;
+	// Contenu par défaut
+  const DEFAULT_CONTENT = `Editeur de Markdown
 ======
 
-Sous-titre
+Notice d'utilisation
 -----------
+
+Vous pouvez effacer ce contenu par défaut, et il sera sauvegardé dans votre navigateur. 
+
+Si vous revenez ici, le contenu précédemment sauvegardé sera rechargé.
+
+Le bouton 🙈/👀 tout en haut à droite de cette page, permet de masquer ou afficher le panneau avec l'éditeur.
+
+Ce que vous lisez actuellement est le rendu HTML du contenu Markdown saisi dans l'éditeur. 
+Celui-ci se met à jour dynamiquement.
+
+J'utilise la librairie [marked.js](https://marked.js.org/) pour calculer ce rendu, contrairement au reste de ce blog qui habituellement utilise une autre chaîne de transformation \`markdown -> HTML\`.
+
+Donc pour le moment, on ne peut pas évaluer dynamiquement de code Svelte, on ne peut pas mettre de code PlantUML pour générer des diagrammes, les Emojis ne sont pas automatiquement transformés en Twemojis, il n'y a pas de liens générés pour les headers, etc.
+
+On peut quand même s'amuser un peu malgré tout !
+
+Ci-dessous des exemples de Markdown pour en apprécier le rendu.
 
 # Titre alternatif
 
@@ -40,7 +62,7 @@ texte tout seul; Les caractères _italiques_, **gras**, \`à taille fixe\`.
 
 [un lien](https://lacourt.dev)
 
-![favicon](/favicon.ico)
+Une tête de vainqueur : ![favicon](/favicon.ico)
 
 > Markdown utilise les caractères à la manière des emails pour faire des citations en bloc.
 >
@@ -61,80 +83,226 @@ code
    alors
 \`\`\`
 ---
-`
+`;
+
+
+	// Fonction pour charger le contenu initial depuis le localStorage ou utiliser le défaut
+	function getInitialContent(): string {
+		if (typeof window !== 'undefined' && window.localStorage) {
+			const storedContent = localStorage.getItem(CONTENT_STORAGE_KEY);
+			return storedContent !== null ? storedContent : DEFAULT_CONTENT;
+		}
+		return DEFAULT_CONTENT; // Fallback pour SSR ou si localStorage n'est pas dispo
+	}
+
+	// 1. État pour le contenu brut du textarea
+	// Initialisé avec la valeur du localStorage ou la valeur par défaut
+	let rawContent = $state(getInitialContent());
+
+	// 2. État dérivé pour le contenu HTML transformé par marked
+	// Se met à jour automatiquement quand rawContent change
+	let renderedHtml = $derived(marked(rawContent));
+
+  // Pour gérer l'affichage/masquage de l'editeur Markdown.
+  let showPanel = $state(true);
+
+	// 3. Effet pour sauvegarder le contenu dans le localStorage
+	// S'exécute chaque fois que rawContent change, après que l'état ait été mis à jour
+	$effect(() => {
+		if (typeof window !== 'undefined' && window.localStorage) {
+			localStorage.setItem(CONTENT_STORAGE_KEY, rawContent);
+			console.log('Contenu sauvegardé dans localStorage:', rawContent);
+		}
+	});
+
+	// Optionnel : une fonction pour réinitialiser au contenu par défaut explicite
+	function resetToDefault() {
+		rawContent = DEFAULT_CONTENT;
+	}
+
+	// Optionnel : une fonction pour vider le contenu
+	function clearContent() {
+		rawContent = '';
+	}
+
+  // --- Gestion de la visibilité de l'éditeur ---
+	function getInitialEditorVisibility(): boolean {
+		if (typeof window !== 'undefined' && window.localStorage) {
+			const storedVisibility = localStorage.getItem(EDITOR_VISIBILITY_KEY);
+			// localStorage stocke des chaînes, donc on compare à "true"
+			return storedVisibility !== null ? storedVisibility === 'true' : DEFAULT_EDITOR_VISIBLE;
+		}
+		return DEFAULT_EDITOR_VISIBLE;
+	}
+
+	let isEditorVisible = $state(getInitialEditorVisibility());
+
+	$effect(() => {
+		if (typeof window !== 'undefined' && window.localStorage) {
+			// Stocker comme une chaîne "true" ou "false"
+			localStorage.setItem(EDITOR_VISIBILITY_KEY, String(isEditorVisible));
+			// console.log('Visibilité éditeur sauvegardée:', isEditorVisible); // Décommenter pour debug
+		}
+	});
+
+  function togglePanelVisibility() {
+    showPanel = !showPanel;
+  }
+
 </script>
 
+<button id="toggle-visibility" aria-label={showPanel ? 'masquer editeur':'afficher editeur'} onclick={togglePanelVisibility}>{showPanel ? '🙈':'👀'}</button>
 
-<h1>Markdown Editor</h1>
+<div class="markdown-editor-container">
+  {#if showPanel}
+	<div class="editor-pane">
+		<textarea bind:value={rawContent} rows="10" placeholder="Écrivez votre Markdown ici..."></textarea>
+		<div class="controls">
+			<button onclick={resetToDefault}>Réinitialiser à "coucou"</button>
+			<button onclick={clearContent}>Vider</button>
+		</div>
+	</div>
+  {/if}
 
-<!-- Declare a textarea where the user can enter markdown, and bind it to the variable `markdown` -->
-<textarea bind:value={markdown} placeholder="Enter markdown here"></textarea>
+	<div class="preview-pane">
+		<div class="preview-content">
+			{@html renderedHtml}
+		</div>
+	</div>
+</div>
 
-<!-- Convert the markdown to HTML and display it -->
-<div class="preview">{@html marked(markdown)}</div>
-
-<!-- Make it look (slightly) nicer ;) -->
 <style>
-	textarea, .preview {
-		box-sizing: border-box;
-		display: block;
-		width: 100%;
+
+  #toggle-visibility {
+    width: 30px;
+    float: right;
+    position: absolute;
+    top: 50px;
+    right: 30px;
+  }
+	.markdown-editor-container {
+		display: flex;
+    flex-direction: column;
+		gap: 20px;
+		font-family: sans-serif;
 	}
-	
+	.editor-pane {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		border: 1px solid #ccc;
+		border-radius: 8px;
+		padding: 15px;
+		background-color: #f9f9f9;
+	}
+  h1 {
+    margin: 0 0 2rem 0;
+  }
+	h3 {
+		margin-top: 0;
+		color: #333;
+	}
 	textarea {
-		font-family: monospace, Roboto;
-		height: 25%;
-		border: none;
-		margin: 0;
-		padding: 1rem;
+		width: 100%;
+		min-height: 200px; /* Hauteur minimale */
+		box-sizing: border-box; /* Inclut padding et bordure dans la largeur/hauteur totale */
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		padding: 10px;
+		font-family: monospace;
+		font-size: 14px;
+		margin-bottom: 10px;
+		resize: vertical; /* Permet le redimensionnement vertical */
 	}
-	
-	.preview {
-		height: 75%;
-		padding: 2rem;
-		border-top: solid 2px #888;
-	}
-	
-	h1 {
-		background: #e1e1e1;
-		margin: 0px;
-		padding: 0.8rem;
-		font-size: 1.2rem;
-	}
-	
+  .preview-content {
+    padding: 2rem;
+    border-radius: 4px;
+  }
+  .preview-content :global(h1),
+  .preview-content :global(h2),
+  .preview-content :global(h3),
+  .preview-content :global(h4),
+  .preview-content :global(h5),
+  .preview-content :global(h6) {
+      margin-top: 0.5em;
+      margin-bottom: 0.25em;
+  }
+  .preview-content :global(p) {
+      margin-top: 0;
+      margin-bottom: 0.5em;
+  }
+  .preview-content :global(pre) {
+      background-color: #2d2d2d;
+      color: #f0f0f0;
+      padding: 1em;
+      border-radius: 4px;
+      overflow-x: auto;
+  }
+  .preview-content :global(code) {
+      font-family: monospace;
+      background-color: #eee;
+      padding: 0.2em 0.4em;
+      border-radius: 3px;
+  }
+  .preview-content :global(pre) > :global(code) {
+      background-color: transparent;
+      padding: 0;
+  }
+
+
 	:global(body) {
 		padding: 0;
 	}
 
-  :global(ul) {
+  .preview-content h1 {
+    padding: 4rem 0 2rem 0;
+  }
+  .preview-content :global(ul) {
     list-style-type: disc;
   }
 
-  :global(li) {
+  .preview-content :global(li) {
     margin: 0;
     margin-left: 1em;
   }
 
-  :global(ul ul) {
+  .preview-content :global(ul ul) {
     list-style-type: circle;
   }
 
-  :global(ul ul ul) {
+  .preview-content :global(ul ul ul) {
     list-style-type: square;
   }
 
-  :global(table) {
+  .preview-content :global(table) {
     width: 100%;
     border: 1px solid lightgrey;
   }
-  :global(thead) {
+  .preview-content :global(thead) {
     background-color: #e1e1e1;
   }
-  :global(td) {
+  .preview-content :global(td) {
     border: 1px solid lightgrey;
   }
-  :global(tr:nth-child(2n)) {
+  .preview-content :global(tr:nth-child(2n)) {
     background-color: #f1f1f1;
   }
 
+	.controls {
+		margin-top: 10px;
+		display: flex;
+		gap: 10px;
+	}
+	.controls button {
+		padding: 8px 15px;
+		border: none;
+		border-radius: 4px;
+		background-color: #007bff;
+		color: white;
+		cursor: pointer;
+		font-size: 14px;
+	}
+	.controls button:hover {
+		background-color: #0056b3;
+	}
 </style>

--- a/src/routes/playground/tab-counter/+page.svelte
+++ b/src/routes/playground/tab-counter/+page.svelte
@@ -3,57 +3,89 @@
   import { onMount } from "svelte";
   import { favicon } from "$lib/stores/favicon";
 
-  let suffix = "⏹";
-  let title = "00:00";
-  let t : Timer;
-  let intervalHandler;
-  let perf;
+  // CORRECT WAY to define props with default values and expose as attributes
+  // The default value for the prop itself is handled by JavaScript's destructuring default.
+  // The `attribute: true` option is passed directly to the prop definition,
+  // indicating it should sync with an HTML attribute.
+  const {
+    showHelp = "true", // JavaScript default value
+    updateTitleWithTimeElapsed = "true" // JavaScript default value
+  } = $props<{
+    showHelp?: string; // Mark as optional as it might not be provided via prop or attribute
+    updateTitleWithTimeElapsed?: string; // Mark as optional
+  }, {
+    attribute: true; // This applies to ALL props in this $props() block
+  }>();
+
+  let suffix = $state("⏹");
+  let title = $state("00:00");
+  let t = $state<Timer | undefined>(undefined); // Typage avec undefined car il est initialisé plus tard
+  let intervalHandler: ReturnType<typeof setInterval> | undefined = $state(undefined);
+  let perf: Performance | undefined = $state(undefined);
 
   function formatElapsed(elapsed: number) {
-    let minutes = Math.floor(elapsed / (60*1000));
-    let seconds = Math.floor((elapsed % (60*1000))/1000);
-    let text = `${minutes < 10 ? ("0" + minutes) : minutes}:${seconds < 10 ? ("0" + seconds) : seconds}`;
+    let minutes = Math.floor(elapsed / (60 * 1000));
+    let seconds = Math.floor((elapsed % (60 * 1000)) / 1000);
+    let text = `${minutes < 10 ? "0" + minutes : minutes}:${seconds < 10 ? "0" + seconds : seconds}`;
     return text;
   }
 
-  let stopTimer = () => {
-    t.stop();
-    title = formatElapsed(t.elapsed);
+  const stopTimer = () => {
+    if (t) { // Vérifier si t est défini avant d'appeler stop()
+      t.stop();
+      title = formatElapsed(t.elapsed);
+    }
     suffix = "⏸";
-    if (intervalHandler) clearInterval(intervalHandler);
-    t.update();
+    if (intervalHandler) {
+      clearInterval(intervalHandler);
+      intervalHandler = undefined; // Réinitialiser pour éviter de le conserver
+    }
   };
 
-  let continueTimer = () => {
-    t.start();
-    if (intervalHandler) clearInterval(intervalHandler);
+  const continueTimer = () => {
+    if (t) { // Vérifier si t est défini avant d'appeler start()
+      t.start();
+    } else {
+      // Si le timer n'a pas été démarré, le démarrer
+      startTimer();
+      return; // Sortir après le démarrage pour éviter le double intervalle
+    }
+    if (intervalHandler) {
+      clearInterval(intervalHandler);
+    }
     intervalHandler = setInterval(() => {
-      t.update();
-      title = formatElapsed(t.elapsed);
+      if (t) {
+        t.update();
+        title = formatElapsed(t.elapsed);
+      }
       suffix = "⏵";
     }, 1000);
   };
 
-  let startTimer = () => {
+  const startTimer = () => {
     title = "00:00";
     suffix = "⏵";
     t = new Timer({
       duration: 30 * 60 * 1000,
       elapsed: 0,
-      perf
+      perf: perf! // Utilisation de l'opérateur non-null assertion car perf sera initialisé au onMount
     });
 
-    if (intervalHandler) clearInterval(intervalHandler);
+    if (intervalHandler) {
+      clearInterval(intervalHandler);
+    }
 
     t.start();
     intervalHandler = setInterval(() => {
-      t.update();
-      title = formatElapsed(t.elapsed);
+      if (t) {
+        t.update();
+        title = formatElapsed(t.elapsed);
+      }
     }, 1000);
   };
 
   onMount(async () => {
-    favicon.set('https://fav.farm/%E2%8F%B1');
+    favicon.set("https://fav.farm/%E2%8F%B1");
 
     // il faut attendre pour avoir accès à `window` sinon on est hors navigateur (SSR, etc.)
     perf = window.performance;
@@ -61,61 +93,66 @@
 </script>
 
 <style>
-h1 {
-  color: violet;
-}
-h2 {
-  margin-top: 10px;
-}
-.elapsed {
-  display: inline-block;
-  font-size: 20vmin;
-  font-family: monospace;
-}
-.flexed {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.buttons {
-  display: flex;
-}
-button {
-  width: 120px;
-  height: 50px;
-  margin: 10px;
-  padding: 10px;
-}
-.about {
-  margin: 20px;
-  padding: 20px;
-  font-size: small;
-  background-color: lightcyan;
-}
+  h1 {
+    color: violet;
+  }
+  h2 {
+    margin-top: 10px;
+  }
+  .elapsed {
+    display: inline-block;
+    font-size: 20vmin;
+    font-family: monospace;
+  }
+  .flexed {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .buttons {
+    display: flex;
+  }
+  button {
+    width: 120px;
+    height: 50px;
+    margin: 10px;
+    padding: 10px;
+  }
+  .about {
+    margin: 20px;
+    padding: 20px;
+    font-size: small;
+    background-color: lightcyan;
+  }
 </style>
 
+<svelte:options customElement="tab-counter" />
+
 <svelte:head>
-    <title>{ title }{ suffix ? " " + suffix : "" }</title> 
+  {#if updateTitleWithTimeElapsed === 'true'}
+    <title>{title}{suffix ? " " + suffix : ""}</title>
+  {/if}
 </svelte:head>
 
 <h1>Tab Counter</h1>
 <div class="flexed">
   <h2>Temps écoulé {suffix}:</h2>
-  <div class="elapsed">{ title }</div>
+  <div class="elapsed">{title}</div>
 
   <div class="buttons">
-    <button on:click={startTimer}>↪ | redémarrer</button>
-    <button on:click={stopTimer}>⏸ | arrêter</button>
-    <button on:click={continueTimer}>▶ | continuer</button>
+    <button onclick={startTimer}>↪ | redémarrer</button>
+    <button onclick={stopTimer}>⏸ | arrêter</button>
+    <button onclick={continueTimer}>▶ | continuer</button>
   </div>
-  <div class="about">
-    <p>Un time-boxer qui s’affiche dans le titre de l'onglet (title page)</p>
-    <p>La favicon vient de <a href="https://fav.farm">fav.farm</a></p>
-  </div>
-  
+  {#if showHelp === 'true'}
+    <div class="about">
+      <p>Un time-boxer qui s’affiche dans le titre de l'onglet (title page)</p>
+      <p>La favicon vient de <a href="https://fav.farm">fav.farm</a></p>
+    </div>
+  {/if}
 </div>
 
-<br/>
-<br/>
-<br/>
-<br/>
+<br />
+<br />
+<br />
+<br />


### PR DESCRIPTION
- updates the playground/md tool to save the contents to localstorage.
- the example also explains (in french) how to use it.
- import tab-counter as a Custom Element with attributes as props to disable some features (show help, show elapsed in tab title)